### PR TITLE
Update Caddyfile

### DIFF
--- a/frankenphp/Caddyfile
+++ b/frankenphp/Caddyfile
@@ -1,21 +1,21 @@
 {
-	{$CADDY_GLOBAL_OPTIONS}
+        {$CADDY_GLOBAL_OPTIONS}
 
-	frankenphp {
-		{$FRANKENPHP_CONFIG}
-	}
+        frankenphp {
+                {$FRANKENPHP_CONFIG}
+        }
 }
 
 {$CADDY_EXTRA_CONFIG}
 
-{$SERVER_NAME:localhost} {
-	root * /app/public
-	encode zstd br gzip
+{$SERVER_NAME: :80} {
+        root * /app/public
+        encode zstd br gzip
 
-	{$CADDY_SERVER_EXTRA_DIRECTIVES}
+        {$CADDY_SERVER_EXTRA_DIRECTIVES}
 
-	# Disable Topics tracking if not enabled explicitly: https://github.com/jkarlin/topics
-	header ?Permissions-Policy "browsing-topics=()"
+        # Disable Topics tracking if not enabled explicitly: https://github.com/jkarlin/topics
+        header ?Permissions-Policy "browsing-topics=()"
 
-	php_server
+        php_server
 }


### PR DESCRIPTION
.	${SERVER_NAME: :80}:
	•	This line uses the ${VARIABLE:default_value} syntax provided by Caddy to define the server block.
	•	SERVER_NAME is the environment variable that you can set with a specific domain or hostname.
	•	:80 is the default value if SERVER_NAME is not set. This means that if SERVER_NAME is not provided, Caddy will listen on port 80 for all incoming hostnames.

## Describe your changes

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] Commit names follow the [Conventional Commits](https://www.conventionalcommits.org/fr/v1.0.0/) convention
- [x] I have checked the entire code before submitting it
- [x] I have updated the documentation related to my commits
- [x] My code does not generate errors
