### PR TITLE
feat: count purchase failures

### DIFF
--- a/migrations/Version20260517203154.php
+++ b/migrations/Version20260517203154.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260517203154 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add domain_purchase columns';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE domain_purchase DROP CONSTRAINT FK_72999E74A76ED395');
+        $this->addSql('ALTER TABLE domain_purchase ADD type VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE domain_purchase ADD exception_class VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE domain_purchase ADD reason VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE domain_purchase ADD exception_message VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE domain_purchase ALTER user_id SET NOT NULL');
+        $this->addSql('ALTER TABLE domain_purchase ADD CONSTRAINT FK_72999E74A76ED395 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_72999E74115F0EE5D2E041DAEE8CBF73A76ED395 ON domain_purchase (domain_id, domain_updated_at, domain_ordered_at, user_id)');
+
+        $this->addSql('UPDATE domain_purchase SET type = \'success\' WHERE domain_ordered_at IS NOT NULL');
+        $this->addSql('UPDATE domain_purchase SET type = \'failure\' WHERE domain_ordered_at IS NULL');
+
+        $this->addSql('ALTER TABLE domain_purchase ALTER type SET NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE domain_purchase DROP CONSTRAINT fk_72999e74a76ed395');
+        $this->addSql('DROP INDEX UNIQ_72999E74115F0EE5D2E041DAEE8CBF73A76ED395');
+        $this->addSql('ALTER TABLE domain_purchase DROP type');
+        $this->addSql('ALTER TABLE domain_purchase DROP exception_class');
+        $this->addSql('ALTER TABLE domain_purchase DROP reason');
+        $this->addSql('ALTER TABLE domain_purchase DROP exception_message');
+        $this->addSql('ALTER TABLE domain_purchase ALTER user_id DROP NOT NULL');
+        $this->addSql('ALTER TABLE domain_purchase ADD CONSTRAINT fk_72999e74a76ed395 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+}

--- a/src/Config/DomainPurchaseFailureReason.php
+++ b/src/Config/DomainPurchaseFailureReason.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Config;
+
+enum DomainPurchaseFailureReason: string
+{
+    case AlreadyRegistered = 'registered';
+    case Exception = 'exception';
+}

--- a/src/Entity/DomainPurchase.php
+++ b/src/Entity/DomainPurchase.php
@@ -7,8 +7,12 @@ use App\Repository\DomainPurchaseRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Uuid;
 
+#[ORM\UniqueConstraint(columns: ['domain_id', 'domain_updated_at', 'domain_ordered_at', 'user_id'])]
 #[ORM\Entity(repositoryClass: DomainPurchaseRepository::class)]
-class DomainPurchase
+#[ORM\InheritanceType('SINGLE_TABLE')]
+#[ORM\DiscriminatorColumn(name: 'type', type: 'string')]
+#[ORM\DiscriminatorMap(['success' => DomainPurchaseSuccess::class, 'failure' => DomainPurchaseFailure::class])]
+abstract class DomainPurchase
 {
     #[ORM\Id]
     #[ORM\Column(type: 'uuid')]
@@ -21,9 +25,6 @@ class DomainPurchase
     #[ORM\Column]
     private ?\DateTimeImmutable $domainUpdatedAt = null;
 
-    #[ORM\Column(nullable: true)]
-    private ?\DateTimeImmutable $domainOrderedAt = null;
-
     #[ORM\Column(enumType: ConnectorProvider::class)]
     private ?ConnectorProvider $connectorProvider = null;
 
@@ -32,7 +33,7 @@ class DomainPurchase
     private ?Connector $connector = null;
 
     #[ORM\ManyToOne(inversedBy: 'domainPurchases')]
-    #[ORM\JoinColumn(referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    #[ORM\JoinColumn(referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     private ?User $user = null;
 
     #[ORM\Column]
@@ -68,18 +69,6 @@ class DomainPurchase
     public function setDomainUpdatedAt(\DateTimeImmutable $domainUpdatedAt): static
     {
         $this->domainUpdatedAt = $domainUpdatedAt;
-
-        return $this;
-    }
-
-    public function getDomainOrderedAt(): ?\DateTimeImmutable
-    {
-        return $this->domainOrderedAt;
-    }
-
-    public function setDomainOrderedAt(?\DateTimeImmutable $domainOrderedAt): static
-    {
-        $this->domainOrderedAt = $domainOrderedAt;
 
         return $this;
     }

--- a/src/Entity/DomainPurchaseFailure.php
+++ b/src/Entity/DomainPurchaseFailure.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Entity;
+
+use App\Config\DomainPurchaseFailureReason;
+use App\Repository\DomainPurchaseRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: DomainPurchaseRepository::class)]
+class DomainPurchaseFailure extends DomainPurchase
+{
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $exceptionClass = null;
+
+    #[ORM\Column(nullable: true, enumType: DomainPurchaseFailureReason::class)]
+    private ?DomainPurchaseFailureReason $reason = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $exceptionMessage = null;
+
+    public function getExceptionClass(): ?string
+    {
+        return $this->exceptionClass;
+    }
+
+    public function setExceptionClass(?string $exceptionClass): self
+    {
+        $this->exceptionClass = $exceptionClass;
+
+        return $this;
+    }
+
+    public function getReason(): ?DomainPurchaseFailureReason
+    {
+        return $this->reason;
+    }
+
+    public function setReason(?DomainPurchaseFailureReason $reason): self
+    {
+        $this->reason = $reason;
+
+        return $this;
+    }
+
+    public function getExceptionMessage(): ?string
+    {
+        return $this->exceptionMessage;
+    }
+
+    public function setExceptionMessage(?string $exceptionMessage): self
+    {
+        $this->exceptionMessage = $exceptionMessage;
+
+        return $this;
+    }
+}

--- a/src/Entity/DomainPurchaseSuccess.php
+++ b/src/Entity/DomainPurchaseSuccess.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class DomainPurchaseSuccess extends DomainPurchase
+{
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $domainOrderedAt = null;
+
+    public function setDomainOrderedAt(?\DateTimeImmutable $domainOrderedAt): self
+    {
+        $this->domainOrderedAt = $domainOrderedAt;
+
+        return $this;
+    }
+
+    public function getDomainOrderedAt(): ?\DateTimeImmutable
+    {
+        return $this->domainOrderedAt;
+    }
+}

--- a/src/MessageHandler/DetectDomainChangeHandler.php
+++ b/src/MessageHandler/DetectDomainChangeHandler.php
@@ -2,8 +2,11 @@
 
 namespace App\MessageHandler;
 
+use App\Config\DomainPurchaseFailureReason;
+use App\Config\EventAction;
 use App\Entity\Domain;
 use App\Entity\DomainEvent;
+use App\Entity\DomainPurchaseFailure;
 use App\Entity\DomainStatus;
 use App\Entity\Watchlist;
 use App\Message\DetectDomainChange;
@@ -16,6 +19,8 @@ use App\Repository\WatchlistRepository;
 use App\Service\ChatNotificationService;
 use App\Service\InfluxdbService;
 use App\Service\StatService;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
@@ -43,6 +48,7 @@ final readonly class DetectDomainChangeHandler
         private InfluxdbService $influxdbService,
         private DomainEventRepository $domainEventRepository,
         private DomainStatusRepository $domainStatusRepository,
+        private EntityManagerInterface $entityManager,
     ) {
         $this->sender = new Address($mailerSenderEmail, $mailerSenderName);
     }
@@ -143,6 +149,30 @@ final readonly class DetectDomainChangeHandler
             }
 
             $this->statService->incrementStat('stats.alert.sent');
+        }
+
+        $this->updateDomainPurchaseFailure($domain, $watchlist, $message);
+    }
+
+    private function updateDomainPurchaseFailure(Domain $domain, Watchlist $watchlist, DetectDomainChange $message): void
+    {
+        $registrationEvent = $this->domainEventRepository->findLastDomainEventByEventAction($domain, EventAction::Registration, false);
+        if (!$registrationEvent || $registrationEvent->getDate() <= $message->updatedAt) {
+            return;
+        }
+
+        $this->entityManager->persist((new DomainPurchaseFailure())
+            ->setDomain($domain)
+            ->setConnector($watchlist->getConnector())
+            ->setReason(DomainPurchaseFailureReason::AlreadyRegistered)
+            ->setConnectorProvider($watchlist->getConnector()->getProvider())
+            ->setUser($watchlist->getUser())
+            ->setDomainDeletedAt($domain->getUpdatedAt())
+            ->setDomainUpdatedAt($message->updatedAt));
+
+        try {
+            $this->entityManager->flush();
+        } catch (UniqueConstraintViolationException) {
         }
     }
 }

--- a/src/MessageHandler/OrderDomainHandler.php
+++ b/src/MessageHandler/OrderDomainHandler.php
@@ -2,8 +2,10 @@
 
 namespace App\MessageHandler;
 
+use App\Config\DomainPurchaseFailureReason;
 use App\Entity\Domain;
-use App\Entity\DomainPurchase;
+use App\Entity\DomainPurchaseFailure;
+use App\Entity\DomainPurchaseSuccess;
 use App\Entity\Watchlist;
 use App\Message\OrderDomain;
 use App\Notifier\DomainOrderErrorNotification;
@@ -14,6 +16,7 @@ use App\Repository\WatchlistRepository;
 use App\Service\ChatNotificationService;
 use App\Service\InfluxdbService;
 use App\Service\Provider\AbstractProvider;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -144,7 +147,7 @@ final readonly class OrderDomainHandler
             ]);
 
             if (null === $domainPurchase) {
-                $this->em->persist((new DomainPurchase())
+                $this->em->persist((new DomainPurchaseSuccess())
                     ->setDomain($domain)
                     ->setConnector($connector)
                     ->setConnectorProvider($connector->getProvider())
@@ -174,28 +177,30 @@ final readonly class OrderDomainHandler
             $this->mailer->send($notification->asEmailMessage(new Recipient($watchlist->getUser()->getEmail()))->getMessage());
             $this->chatNotificationService->sendChatNotification($watchlist, $notification);
 
-            $domainPurchase = $this->domainPurchaseRepository->findOneBy([
-                'domain' => $domain,
-                'connector' => $connector,
-                'domainOrderedAt' => null,
-                'domainUpdatedAt' => $message->updatedAt,
-                'user' => $watchlist->getUser(),
-            ]);
-            if (null === $domainPurchase) {
-                $this->em->persist((new DomainPurchase())
-                    ->setDomain($domain)
-                    ->setConnector($connector)
-                    ->setConnectorProvider($connector->getProvider())
-                    ->setDomainOrderedAt(null)
-                    ->setUser($watchlist->getUser())
-                    ->setDomainDeletedAt($domain->getUpdatedAt())
-                    ->setDomainUpdatedAt($message->updatedAt));
-                $this->em->flush();
-            }
+            $this->updateDomainPurchaseFailure($domain, $watchlist, $message, $exception);
 
             $lock->release();
 
             throw $exception;
+        }
+    }
+
+    private function updateDomainPurchaseFailure(Domain $domain, Watchlist $watchlist, OrderDomain $message, \Throwable $throwable): void
+    {
+        $this->em->persist((new DomainPurchaseFailure())
+            ->setDomain($domain)
+            ->setExceptionClass($throwable::class)
+            ->setExceptionMessage(substr($throwable->getMessage(), 0, 255))
+            ->setConnector($watchlist->getConnector())
+            ->setReason(DomainPurchaseFailureReason::Exception)
+            ->setConnectorProvider($watchlist->getConnector()->getProvider())
+            ->setUser($watchlist->getUser())
+            ->setDomainDeletedAt($domain->getUpdatedAt())
+            ->setDomainUpdatedAt($message->updatedAt));
+
+        try {
+            $this->em->flush();
+        } catch (UniqueConstraintViolationException) {
         }
     }
 }

--- a/src/Repository/DomainEventRepository.php
+++ b/src/Repository/DomainEventRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repository;
 
+use App\Config\EventAction;
 use App\Entity\Domain;
 use App\Entity\DomainEvent;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
@@ -57,28 +58,18 @@ class DomainEventRepository extends ServiceEntityRepository
             ->execute();
     }
 
-    //    /**
-    //     * @return DomainEvent[] Returns an array of DomainEvent objects
-    //     */
-    //    public function findByExampleField($value): array
-    //    {
-    //        return $this->createQueryBuilder('e')
-    //            ->andWhere('e.exampleField = :val')
-    //            ->setParameter('val', $value)
-    //            ->orderBy('e.id', 'ASC')
-    //            ->setMaxResults(10)
-    //            ->getQuery()
-    //            ->getResult()
-    //        ;
-    //    }
-
-    //    public function findOneBySomeField($value): ?DomainEvent
-    //    {
-    //        return $this->createQueryBuilder('e')
-    //            ->andWhere('e.exampleField = :val')
-    //            ->setParameter('val', $value)
-    //            ->getQuery()
-    //            ->getOneOrNullResult()
-    //        ;
-    //    }
+    public function findLastDomainEventByEventAction(Domain $domain, EventAction $eventAction, bool $deleted): ?DomainEvent
+    {
+        return $this->createQueryBuilder('de')
+            ->select()
+            ->where('de.domain = :domain')
+            ->andWhere('de.action = :action')
+            ->andWhere('de.deleted = :deleted')
+            ->orderBy('de.date', 'DESC')
+            ->setParameter('deleted', $deleted)
+            ->setParameter('domain', $domain)
+            ->setParameter('action', $eventAction)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
 }


### PR DESCRIPTION
## Describe your changes

When a domain name is on a watchlist with a connector, DW must detect if a new registration has occurred before it can successfully order it.
If so, the information must be persisted in the database even if no purchase attempt has taken place.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [x] Commit names follow the [Conventional Commits](https://www.conventionalcommits.org/fr/v1.0.0/) convention
- [x] I have checked the entire code before submitting it
- [x] I have updated the documentation related to my commits
- [x] My code does not generate errors
